### PR TITLE
Setting user search

### DIFF
--- a/app/controllers/api/me/accounts_controller.rb
+++ b/app/controllers/api/me/accounts_controller.rb
@@ -2,7 +2,8 @@ class Api::Me::AccountsController < ApplicationController
   before_action :authenticate
 
   def update
-    current_user.update(user_params)
+    current_user.assign_attributes(user_params)
+    current_user.save_with_tags!(tag_names: tag_names)
     render json: current_user, serializer: UserSerializer
   end
 
@@ -10,5 +11,9 @@ class Api::Me::AccountsController < ApplicationController
 
   def user_params
     params.require(:user).permit(:name, :introduction, :avatar, avatar: :data)
+  end
+
+  def tag_names
+    params.dig(:user, :tag_names)
   end
 end

--- a/app/controllers/api/tags_controller.rb
+++ b/app/controllers/api/tags_controller.rb
@@ -1,0 +1,6 @@
+class Api::TagsController < ApplicationController
+  def index
+    tags = Tag.all
+    render json: tags, each_serializer: TagSerializer
+  end
+end

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -1,4 +1,12 @@
 class Api::UsersController < ApplicationController
+  PER_PAGE = 12
+  def index
+    users = User.order(created_at: :desc).page(params[:page]).per(PER_PAGE)
+    render json: users, each_serializer: UserSerializer, meta: { total_pages: users.total_pages,
+                                                                           total_count: users.total_count,
+                                                                           current_page: users.current_page }
+  end
+  
   def create
     user = User.new(user_params)
     user.save!

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -1,12 +1,13 @@
 class Api::UsersController < ApplicationController
   PER_PAGE = 12
   def index
-    users = User.order(created_at: :desc).page(params[:page]).per(PER_PAGE)
+    search_users_form = SearchUsersForm.new(search_params)
+    users = search_users_form.search.order(created_at: :desc).page(params[:page]).per(PER_PAGE)
     render json: users, each_serializer: UserSerializer, meta: { total_pages: users.total_pages,
                                                                            total_count: users.total_count,
                                                                            current_page: users.current_page }
   end
-  
+
   def create
     user = User.new(user_params)
     user.save!
@@ -22,5 +23,9 @@ class Api::UsersController < ApplicationController
 
   def user_params
     params.require(:user).permit(:name, :email, :password, :password_confirmation)
+  end
+
+  def search_params
+    params[:q]&.permit(:name, tag_ids: [])
   end
 end

--- a/app/forms/search_users_form.rb
+++ b/app/forms/search_users_form.rb
@@ -1,0 +1,14 @@
+class SearchUsersForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attribute :name, :string
+  attribute :tag_ids, array: :integer
+
+  def search
+    relation = User.distinct
+    relation = relation.by_name(name) if name.present?
+    relation = relation.by_tag(tag_ids) if tag_ids.present?
+    relation
+  end
+end

--- a/app/javascript/app.vue
+++ b/app/javascript/app.vue
@@ -13,7 +13,15 @@
             <v-list-item-title>ホーム</v-list-item-title>
           </v-list-item-content>
         </v-list-item>
-        <v-list-item to="/profile" link v-if="$store.getters['auth/currentUser']">
+        <v-list-item to="/users" link>
+          <v-list-item-action>
+            <v-icon>mdi-account-group</v-icon>
+          </v-list-item-action>
+          <v-list-item-content>
+            <v-list-item-title>ユーザー</v-list-item-title>
+          </v-list-item-content>
+        </v-list-item>
+        <v-list-item :to="`/users/${$store.getters['auth/currentUser'].id}`" link v-if="$store.getters['auth/currentUser']">
           <v-list-item-action>
             <v-icon>mdi-account</v-icon>
           </v-list-item-action>
@@ -50,7 +58,19 @@
     </v-app-bar>
 
     <v-main>
-      <router-view></router-view>
+      <v-container
+              class="fill-height"
+              fluid
+      >
+        <v-row
+                align="center"
+                justify="center"
+        >
+          <v-col>
+            <router-view></router-view>
+          </v-col>
+        </v-row>
+      </v-container>
     </v-main>
     <v-footer
             color="indigo"

--- a/app/javascript/components/ProfileEditModal.vue
+++ b/app/javascript/components/ProfileEditModal.vue
@@ -14,6 +14,35 @@
               <v-col cols="12">
                 <v-textarea label="Introduction" v-model="user.introduction"></v-textarea>
               </v-col>
+              <v-col cols="12">
+                <template>
+                  <v-container fluid>
+                    <v-combobox
+                            v-model="selectedTags"
+                            :items="tags"
+                            :search-input.sync="search"
+                            hide-selected
+                            hint="最大5つまで登録できます"
+                            label="Add some tags"
+                            multiple
+                            persistent-hint
+                            small-chips
+                            :clearable="true"
+                            :deletable-chips="true"
+                    >
+                      <template v-slot:no-data>
+                        <v-list-item>
+                          <v-list-item-content>
+                            <v-list-item-title>
+                              タグ"<strong>{{ search }}</strong>"はまだ登録されていません。<kbd>enter</kbd>で登録できます。
+                            </v-list-item-title>
+                          </v-list-item-content>
+                        </v-list-item>
+                      </template>
+                    </v-combobox>
+                  </v-container>
+                </template>
+              </v-col>
             </v-row>
           </v-container>
         </v-card-text>
@@ -33,11 +62,18 @@
         data() {
             return {
                 dialog: false,
-                user: null
+                user: null,
+                selectedTags: [],
+                search: null,
+                tags: []
             }
         },
         created() {
             this.user = { ...this.$store.getters['auth/currentUser']}
+            this.selectedTags = this.user.tags.map((tag) => {
+                return tag.name
+            })
+            this.fetchTags()
         },
         methods: {
             open() {
@@ -50,12 +86,26 @@
                 const userParams = {
                     user: {
                         name: this.user.name,
-                        introduction: this.user.introduction
+                        introduction: this.user.introduction,
+                        tag_names: this.selectedTags
                     }
                 }
                 await this.$store.dispatch('auth/updateProfile', userParams)
                 this.close()
+            },
+            async fetchTags() {
+                const res = await axios.get(`/api/tags`)
+                this.tags = res.data.tags.map((tag) => {
+                    return tag.name
+                })
             }
-        }
+        },
+        watch: {
+            selectedTags (val) {
+                if (val.length > 5) {
+                    this.$nextTick(() => this.selectedTags.pop())
+                }
+            },
+        },
     }
 </script>

--- a/app/javascript/pages/PageProfile.vue
+++ b/app/javascript/pages/PageProfile.vue
@@ -50,7 +50,7 @@
 
             <v-divider inset></v-divider>
 
-            <v-list-item >
+            <v-list-item>
               <v-list-item-icon>
                 <v-icon color="indigo">mdi-email</v-icon>
               </v-list-item-icon>
@@ -62,7 +62,7 @@
 
             <v-divider inset></v-divider>
 
-            <v-list-item >
+            <v-list-item>
               <v-list-item-icon>
                 <v-icon color="indigo">mdi-account-details</v-icon>
               </v-list-item-icon>
@@ -75,8 +75,31 @@
                 </v-list-item-title>
               </v-list-item-content>
             </v-list-item>
+
+            <v-divider inset></v-divider>
+
+            <v-list-item >
+              <v-list-item-icon>
+                <v-icon color="indigo">mdi-music-accidental-sharp</v-icon>
+              </v-list-item-icon>
+
+              <v-list-item-content>
+                <v-list-item-title>
+                  <v-chip
+                          class="ma-1"
+                          color="orange"
+                          text-color="white"
+                          small
+                          v-for="tag in user.tags" :key="tag.name"
+                  >
+                    <v-icon left class="mr-0">mdi-music-accidental-sharp</v-icon>
+                    {{tag.name}}
+                  </v-chip>
+                </v-list-item-title>
+              </v-list-item-content>
+            </v-list-item>
           </v-list>
-          <profile-edit-modal ref="dialog"></profile-edit-modal>
+          <profile-edit-modal v-if="isMe" ref="dialog"></profile-edit-modal>
         </v-card>
       </v-col>
     </v-row>

--- a/app/javascript/pages/PageUsers.vue
+++ b/app/javascript/pages/PageUsers.vue
@@ -1,0 +1,62 @@
+<template>
+  <v-container>
+    <v-row dense>
+      <v-col
+              v-for="user in users"
+              :key="user.id"
+              :cols="6"
+              :md="3"
+      >
+        <v-card>
+          <v-img
+                  :src="`http://placeimg.com/300/300/people?dummy=${user.id}`"
+                  class="white--text align-end"
+                  gradient="to bottom, rgba(0,0,0,.1), rgba(0,0,0,.5)"
+          >
+            <v-card-title v-text="user.name"></v-card-title>
+          </v-img>
+
+          <v-card-text class="text--primary">
+            <div>#Ruby</div>
+          </v-card-text>
+
+          <v-card-actions>
+            <v-spacer></v-spacer>
+
+            <v-btn icon>
+              <v-icon>mdi-heart</v-icon>
+            </v-btn>
+
+            <v-btn icon>
+              <v-icon>mdi-bookmark</v-icon>
+            </v-btn>
+
+            <v-btn icon>
+              <v-icon>mdi-share-variant</v-icon>
+            </v-btn>
+          </v-card-actions>
+        </v-card>
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script>
+  import axios from 'axios'
+  export default {
+      data() {
+          return {
+              users: []
+          }
+      },
+      created() {
+          this.fetchUsers()
+      },
+      methods: {
+          async fetchUsers() {
+              const res = await axios.get(`/api/users`)
+              this.users = res.data.users
+          }
+      }
+  }
+</script>

--- a/app/javascript/pages/PageUsers.vue
+++ b/app/javascript/pages/PageUsers.vue
@@ -1,5 +1,33 @@
 <template>
   <v-container>
+    <template>
+      <v-card class="mb-3">
+        <v-card-text>
+          <header>絞り込み条件</header>
+          <v-row dense justify="start">
+            <template>
+              <v-checkbox v-for="tag in tags"
+                          :key="tag.id"
+                          v-model="query.selectedTags"
+                          :label="tag.name"
+                          :value="tag.id"
+                          class="mr-5"
+                          @click.native="fetchUsers"
+                          hide-details="auto"
+              >
+              </v-checkbox>
+            </template>
+          </v-row>
+          <v-row>
+            <template>
+              <v-col cols="12">
+                <v-text-field label="UserName" v-model="query.userName" @input="fetchUsers"></v-text-field>
+              </v-col>
+            </template>
+          </v-row>
+        </v-card-text>
+      </v-card>
+    </template>
     <v-row dense>
       <v-col
               v-for="user in users"
@@ -10,14 +38,34 @@
         <v-card>
           <v-img
                   :src="`http://placeimg.com/300/300/people?dummy=${user.id}`"
+                  :lazy-src="`https://picsum.photos/10/6?dummy=${user.id}`"
                   class="white--text align-end"
                   gradient="to bottom, rgba(0,0,0,.1), rgba(0,0,0,.5)"
+                  aspect-ratio="1"
           >
-            <v-card-title v-text="user.name"></v-card-title>
+            <template v-slot:placeholder>
+              <v-row
+                      class="fill-height ma-0"
+                      align="center"
+                      justify="center"
+              >
+                <v-progress-circular indeterminate color="grey lighten-5"></v-progress-circular>
+              </v-row>
+            </template>
+            <v-card-title v-text="user.name" @click="$router.push(`/users/${user.id}`)" style="cursor: pointer;"></v-card-title>
           </v-img>
 
-          <v-card-text class="text--primary">
-            <div>#Ruby</div>
+          <v-card-text class="text--primary" style="min-height: 64px;">
+            <v-chip
+                    class="ma-1"
+                    color="orange"
+                    text-color="white"
+                    small
+                    v-for="tag in user.tags" :key="tag.name"
+            >
+              <v-icon left class="mr-0">mdi-music-accidental-sharp</v-icon>
+              {{tag.name}}
+            </v-chip>
           </v-card-text>
 
           <v-card-actions>
@@ -38,24 +86,64 @@
         </v-card>
       </v-col>
     </v-row>
+    <v-row justify="center">
+      <template v-if="pagingMeta">
+        <div class="text-center">
+          <v-pagination
+                  color="indigo"
+                  v-model="pagingMeta.current_page"
+                  :length="pagingMeta.total_pages"
+                  @input="paging"
+          ></v-pagination>
+        </div>
+      </template>
+    </v-row>
   </v-container>
 </template>
 
 <script>
   import axios from 'axios'
+  import qs from 'qs';
   export default {
       data() {
           return {
-              users: []
+              users: [],
+              tags: [],
+              query: {
+                  selectedTags: [],
+                  userName: ''
+              },
+              pagingMeta: null,
+              currentPage: 1
           }
       },
       created() {
           this.fetchUsers()
+          this.fetchTags()
       },
       methods: {
           async fetchUsers() {
-              const res = await axios.get(`/api/users`)
+              const searchParams = {
+                  q: {
+                      name: this.query.userName,
+                      tag_ids: this.query.selectedTags
+                  }
+              }
+              const pagingParams = { page: this.currentPage }
+              const params = { ...searchParams, ...pagingParams }
+              const paramsSerializer = (params) => qs.stringify(params, { arrayFormat: 'brackets' });
+              const res = await axios.get(`/api/users`, { params, paramsSerializer })
               this.users = res.data.users
+              this.pagingMeta = res.data.meta
+          },
+          async fetchTags() {
+              const res = await axios.get(`/api/tags`)
+              this.tags = res.data.tags
+          },
+          paging(page) {
+              this.currentPage = page
+              this.fetchUsers()
+              this.$vuetify.goTo(0)
           }
       }
   }

--- a/app/javascript/pages/PageUsers.vue
+++ b/app/javascript/pages/PageUsers.vue
@@ -86,7 +86,7 @@
         </v-card>
       </v-col>
     </v-row>
-    <v-row justify="center">
+    <v-row justify="center" class="pb-10">
       <template v-if="pagingMeta">
         <div class="text-center">
           <v-pagination

--- a/app/javascript/router/index.js
+++ b/app/javascript/router/index.js
@@ -6,6 +6,7 @@ import PageUserLogin from '@/pages/PageUserLogin'
 import PageTimeline from '@/pages/PageTimeline'
 import PageMicropostDetail from '@/pages/PageMicropostDetail'
 import PageProfile from '@/pages/PageProfile'
+import PageUsers from '@/pages/PageUsers'
 
 const router = new VueRouter({
     routes: [
@@ -16,6 +17,7 @@ const router = new VueRouter({
         { path: '/microposts/:id', component: PageMicropostDetail, name: 'micropost-detail' },
         { path: '/profile', component: PageProfile, name: 'user-profile' },
         { path: '/users/:id', component: PageProfile, name: 'user-profile' },
+        { path: '/users', component: PageUsers, name: 'users' },
     ]
 });
 

--- a/app/javascript/router/index.js
+++ b/app/javascript/router/index.js
@@ -15,7 +15,7 @@ const router = new VueRouter({
         { path: '/', component: PageTimeline, name: 'timeline' },
         { path: '/microposts', component: PageTimeline },
         { path: '/microposts/:id', component: PageMicropostDetail, name: 'micropost-detail' },
-        { path: '/profile', component: PageProfile, name: 'user-profile' },
+        { path: '/profile', component: PageProfile, name: 'my-profile' },
         { path: '/users/:id', component: PageProfile, name: 'user-profile' },
         { path: '/users', component: PageUsers, name: 'users' },
     ]

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,0 +1,3 @@
+class Tag < ApplicationRecord
+  validates :name, presence: true, uniqueness: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,4 +12,16 @@ class User < ApplicationRecord
 
   scope :by_name, ->(name) { where('name LIKE ?', "%#{name}%") }
   scope :by_tag, ->(tag_ids) { joins(:user_tags).where(user_tags: { tag_id: tag_ids }) }
+
+  def save_with_tags!(tag_names:)
+    return save! if tag_names.nil? # blank?だと削除ができない
+
+    ActiveRecord::Base.transaction do
+      self.tags = tag_names.map { |name| Tag.find_or_initialize_by(name: name) }
+      save!
+    end
+    true
+  rescue StandardError => e
+    false
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,4 +6,10 @@ class User < ApplicationRecord
 
   has_many :microposts, dependent: :destroy
   has_one_base64_attached :avatar
+
+  has_many :user_tags, dependent: :destroy
+  has_many :tags, through: :user_tags
+
+  scope :by_name, ->(name) { where('name LIKE ?', "%#{name}%") }
+  scope :by_tag, ->(tag_ids) { joins(:user_tags).where(user_tags: { tag_id: tag_ids }) }
 end

--- a/app/models/user_tag.rb
+++ b/app/models/user_tag.rb
@@ -1,0 +1,6 @@
+class UserTag < ApplicationRecord
+  belongs_to :user
+  belongs_to :tag
+
+  validates :user_id, uniqueness: { scope: :tag_id }
+end

--- a/app/serializers/tag_serializer.rb
+++ b/app/serializers/tag_serializer.rb
@@ -1,0 +1,3 @@
+class TagSerializer < ActiveModel::Serializer
+  attributes :id, :name
+end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,6 +1,6 @@
 class UserSerializer < ActiveModel::Serializer
   attributes :id, :name, :email, :introduction, :avatar_url
-
+  has_many :tags
   def avatar_url
     if object.avatar.attached?
       Rails.application.routes.url_helpers.rails_blob_path(object.avatar, only_path: true)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
     resources :users, only: %i[index create show]
     resource :session, only: %i[create destroy]
     resources :microposts, only: %i[index create show update destroy]
+    resources :tags, only: %i[index]
     namespace :me do
       resource :account, only: %i[update]
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   root 'home#index'
   namespace :api do
-    resources :users, only: %i[create show]
+    resources :users, only: %i[index create show]
     resource :session, only: %i[create destroy]
     resources :microposts, only: %i[index create show update destroy]
     namespace :me do

--- a/db/migrate/20210106171555_create_tags.rb
+++ b/db/migrate/20210106171555_create_tags.rb
@@ -1,0 +1,11 @@
+class CreateTags < ActiveRecord::Migration[6.0]
+  def change
+    create_table :tags do |t|
+      t.string :name, null: false
+
+      t.timestamps
+      t.index :name, unique: true
+    end
+
+  end
+end

--- a/db/migrate/20210106171717_create_user_tags.rb
+++ b/db/migrate/20210106171717_create_user_tags.rb
@@ -1,0 +1,11 @@
+class CreateUserTags < ActiveRecord::Migration[6.0]
+  def change
+    create_table :user_tags do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :tag, null: false, foreign_key: true
+
+      t.timestamps
+      t.index [:user_id, :tag_id], unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_06_131703) do
+ActiveRecord::Schema.define(version: 2021_01_06_171717) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -41,6 +41,23 @@ ActiveRecord::Schema.define(version: 2021_01_06_131703) do
     t.index ["user_id"], name: "index_microposts_on_user_id"
   end
 
+  create_table "tags", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["name"], name: "index_tags_on_name", unique: true
+  end
+
+  create_table "user_tags", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "tag_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["tag_id"], name: "index_user_tags_on_tag_id"
+    t.index ["user_id", "tag_id"], name: "index_user_tags_on_user_id_and_tag_id", unique: true
+    t.index ["user_id"], name: "index_user_tags_on_user_id"
+  end
+
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
     t.string "email", null: false
@@ -53,4 +70,6 @@ ActiveRecord::Schema.define(version: 2021_01_06_131703) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "microposts", "users"
+  add_foreign_key "user_tags", "tags"
+  add_foreign_key "user_tags", "users"
 end

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@rails/webpacker": "4.3.0",
     "axios": "^0.21.1",
     "dayjs": "^1.10.2",
+    "qs": "^6.9.4",
     "vue": "^2.6.12",
     "vue-image-crop-upload": "^2.5.0",
     "vue-loader": "^15.9.6",

--- a/test/controllers/api/tags_controller_test.rb
+++ b/test/controllers/api/tags_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class Api::TagsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/tags.yml
+++ b/test/fixtures/tags.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/user_tags.yml
+++ b/test/fixtures/user_tags.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/tag_test.rb
+++ b/test/models/tag_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class TagTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/user_tag_test.rb
+++ b/test/models/user_tag_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class UserTagTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -6025,6 +6025,11 @@ qs@6.7.0:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
 
+qs@^6.9.4:
+  version "6.9.4"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.4.tgz#9090b290d1f91728d3c22e54843ca44aea5ab687"
+  integrity sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ==
+
 qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"


### PR DESCRIPTION
# why
ユーザー同士の繋がりをよりしやすくするための機能

# what
## バックエンド
- 検索するためにuserコントローラーを追記
- tagモデルの作成
- user_tagモデルの作成。多対多のアソシエーション
- userコントローラーにindexアクションを追加(kaminariを使用)

## フロントエンド
- フロントはqs(クエリストリグパーサー)のインストール
- プロフィール編集でタグを追加できるように設定
- userモデルにタグを登録できるメソッドを追加