### PR TITLE
ジャンルタグの設置

### DIFF
--- a/app/controllers/api/genres_controller.rb
+++ b/app/controllers/api/genres_controller.rb
@@ -1,0 +1,6 @@
+class Api::GenresController < ApplicationController
+  def index
+    genres = Genre.all
+    render json: genres, each_serializer: GenreSerializer
+  end
+end

--- a/app/controllers/api/microposts_controller.rb
+++ b/app/controllers/api/microposts_controller.rb
@@ -2,7 +2,8 @@ class Api::MicropostsController < ApplicationController
   before_action :authenticate, only: %i[create update destroy]
   PER_PAGE = 10
   def index
-    microposts = Micropost.includes(:user).order(created_at: :desc).page(params[:page]).per(PER_PAGE)
+    search_microposts_form = SearchMicropostsForm.new(search_params)
+    microposts = search_microposts_form.search.order(created_at: :desc).page(params[:page]).per(PER_PAGE)
     render json: microposts, each_serializer: MicropostSerializer, meta: { total_pages: microposts.total_pages,
                                                                            total_count: microposts.total_count,
                                                                            current_page: microposts.current_page }
@@ -20,7 +21,8 @@ class Api::MicropostsController < ApplicationController
 
   def update
     micropost = current_user.microposts.find(params[:id])
-    micropost.update!(micropost_params)
+    current_user.assign_attributes(micropost_params)
+    current_user.save_with_genres!(genre_names: genre_names)
     render json: micropost, serializer: MicropostSerializer
   end
 
@@ -34,5 +36,13 @@ class Api::MicropostsController < ApplicationController
 
   def micropost_params
     params.permit(:content, :title, :time, :image)
+  end
+
+  def search_params
+    params[:q]&.permit(:name, genre_ids: [])
+  end
+
+  def genre_names
+    params.dig(:genre, :genre_names)
   end
 end

--- a/app/controllers/api/microposts_controller.rb
+++ b/app/controllers/api/microposts_controller.rb
@@ -21,8 +21,8 @@ class Api::MicropostsController < ApplicationController
 
   def update
     micropost = current_user.microposts.find(params[:id])
-    current_user.assign_attributes(micropost_params)
-    current_user.save_with_genres!(genre_names: genre_names)
+    micropost.assign_attributes(micropost_params)
+    micropost.save_with_genres!(genre_names: genre_names)
     render json: micropost, serializer: MicropostSerializer
   end
 
@@ -43,6 +43,6 @@ class Api::MicropostsController < ApplicationController
   end
 
   def genre_names
-    params.dig(:genre, :genre_names)
+    params.dig(:micropost, :genre_names)
   end
 end

--- a/app/forms/search_microposts_form.rb
+++ b/app/forms/search_microposts_form.rb
@@ -1,0 +1,14 @@
+class SearchMicropostsForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attribute :name, :string
+  attribute :genre_ids, array: :integer
+
+  def search
+    relation = Micropost.distinct
+    relation = relation.by_name(name) if name.present?
+    relation = relation.by_genre(genre_ids) if genre_ids.present?
+    relation
+  end
+end

--- a/app/javascript/pages/PageMicropostDetail.vue
+++ b/app/javascript/pages/PageMicropostDetail.vue
@@ -21,6 +21,15 @@
           <div class="display-1 pl-12 pt-12">
             {{ micropost.title }}
           </div>
+          <div v-if="isMine" class="d-flex">
+            <v-btn fab small dark color="teal" @click="openEditMicropost" class="mx-2">
+                <v-icon>mdi-pen</v-icon>
+            </v-btn>
+            <v-btn fab small dark color="error" @click="deleteMicropost" class="mx-2">
+                <v-icon>mdi-delete</v-icon>
+            </v-btn>
+            <micropost-edit-modal v-if="isMine" ref="dialog" :micropost="micropost" @update="updateMicropost"></micropost-edit-modal>
+        </div>
         </v-card-title>
       </v-row>
     </v-img>
@@ -165,10 +174,9 @@ export default {
         openEditMicropost() {
             this.$refs.dialog.open()
         },
-        async updateMicropost(micropostContent) {
-            await axios.patch(`/api/microposts/${this.micropostId}`, { micropost: { content: micropostContent } })
+        async updateMicropost(micropostParams) {
+            await axios.patch(`/api/microposts/${this.micropostId}`, micropostParams);
             this.$refs.dialog.close()
-            this.micropost.content = micropostContent
         },
         async deleteMicropost() {
             if(confirm("削除しますか？")) {

--- a/app/javascript/pages/PagePosts.vue
+++ b/app/javascript/pages/PagePosts.vue
@@ -1,0 +1,148 @@
+<template>
+  <v-container>
+    <template>
+      <v-card class="mb-3">
+        <v-card-text>
+          <header>絞り込み条件</header>
+          <v-row dense justify="start">
+            <template>
+              <v-checkbox v-for="genre in genres"
+                          :key="genre.id"
+                          v-model="query.selectedGenres"
+                          :label="genre.name"
+                          :value="genre.id"
+                          class="mr-5"
+                          @click.native="fetchUsers"
+                          hide-details="auto"
+              >
+              </v-checkbox>
+            </template>
+          </v-row>
+          <v-row>
+            <template>
+              <v-col cols="12">
+                <v-text-field label="UserName" v-model="query.userName" @input="fetchUsers"></v-text-field>
+              </v-col>
+            </template>
+          </v-row>
+        </v-card-text>
+      </v-card>
+    </template>
+    <v-row>
+      <v-col
+        v-for="micropost in microposts" :key="micropost.id" :micropost="micropost"
+        cols="4"
+      >
+        <v-card
+          class="mx-auto"
+          max-width="400"
+        >
+          <v-img
+            class="white--text align-end"
+            height="200px"
+            :src="micropost.image_url"
+            @click="$router.push(`/microposts/${micropost.id}`)"
+          >
+            <v-card-title >
+              <v-list-item-avatar @click="$router.push(`/users/${micropost.user.id}`)">
+                <v-img :src="micropost.user.avatar_url"></v-img>
+              </v-list-item-avatar>
+                {{ micropost.user.name }}
+            </v-card-title>
+          </v-img>
+          <v-card-subtitle class="pb-0">
+            <v-list-item-action-text v-text="$dayjs(micropost.created_at).format('YYYY-MM-DD HH:mm:ss')"></v-list-item-action-text>
+          </v-card-subtitle>
+          <v-card-text class="text--primary">
+            <v-list-item-subtitle style="white-space: pre-line">
+              タイトル: {{ micropost.title }}
+              勉強時間： {{ micropost.time}} h
+            </v-list-item-subtitle>
+            <v-spacer></v-spacer>
+            <v-chip
+                    class="ma-1"
+                    color="orange"
+                    text-color="white"
+                    small
+                   v-for="genre in micropost.genres" :key="genre.name"
+            >
+              <v-icon left class="mr-0">mdi-music-accidental-sharp</v-icon>
+              {{genre.name}}
+            </v-chip>
+          </v-card-text>
+          <v-card-actions>
+              <v-btn icon>
+                <like-button :user-id="micropost.user.id" :micropost-id="micropost.id"></like-button>
+              </v-btn>
+          </v-card-actions>
+        </v-card>
+      </v-col>
+   </v-row>
+  </v-container>
+</template>
+
+<script>
+  import LikeButton from '@/components/LikeButton'
+  import TimelineList from '@/components/TimelineList'
+  import axios from 'axios'
+  import qs from 'qs';
+  export default {
+      data() {
+          return {
+              microposts: [],
+              users: [],
+              genres: [],
+              query: {
+                  selectedGenres: [],
+                  userName: ''
+              },
+              pagingMeta: null,
+              currentPage: 1
+          }
+      },
+      components: {
+            TimelineList,
+            LikeButton
+        },
+      created() {
+          this.fetchUsers()
+          this.fetchGenres()
+          this.fetchMicroposts()
+      },
+      computed: {
+            isExistMicroposts() {
+                return this.microposts.length > 0
+            }
+      },
+      methods: {
+          async fetchMicroposts() {
+                const res = await axios.get(`/api/microposts`, { params: { page: this.currentPage } })
+                this.microposts = res.data.microposts
+                this.pagingMeta = res.data.meta
+          },
+          async fetchUsers() {
+              const searchParams = {
+                  q: {
+                      name: this.query.userName,
+                      genre_ids: this.query.selectedGenres
+                  }
+              }
+              const pagingParams = { page: this.currentPage }
+              const params = { ...searchParams, ...pagingParams }
+              const paramsSerializer = (params) => qs.stringify(params, { arrayFormat: 'brackets' });
+              const res = await axios.get(`/api/users`, { params, paramsSerializer })
+              this.users = res.data.users
+              this.pagingMeta = res.data.meta
+          },
+          async fetchGenres() {
+              const res = await axios.get(`/api/genres`)
+              this.genres = res.data.genres
+          },
+          paging(page) {
+              this.currentPage = page
+              this.fetchUsers()
+              this.$vuetify.goTo(0)
+          }
+      }
+  }
+</script>

--- a/app/javascript/router/index.js
+++ b/app/javascript/router/index.js
@@ -8,6 +8,7 @@ import PageMicropostPost from '@/pages/PageMicropostPost'
 import PageMicropostDetail from '@/pages/PageMicropostDetail'
 import PageProfile from '@/pages/PageProfile'
 import PageUsers from '@/pages/PageUsers'
+import PagePosts from '@/pages/PagePosts'
 
 const router = new VueRouter({
     routes: [
@@ -20,6 +21,7 @@ const router = new VueRouter({
         { path: '/profile', component: PageProfile, name: 'my-profile' },
         { path: '/users/:id', component: PageProfile, name: 'user-profile' },
         { path: '/users', component: PageUsers, name: 'users' },
+        { path: '/post', component: PagePosts, name: 'posts' },
     ]
 });
 

--- a/app/models/genre.rb
+++ b/app/models/genre.rb
@@ -1,0 +1,3 @@
+class Genre < ApplicationRecord
+  validates :name, presence: true, uniqueness: true
+end

--- a/app/models/micropost_genre.rb
+++ b/app/models/micropost_genre.rb
@@ -1,5 +1,5 @@
 class MicropostGenre < ApplicationRecord
-  belongs_to :micropsot
+  belongs_to :micropost
   belongs_to :genre
 
   validates :micropost_id, uniqueness: { scope: :genre_id }

--- a/app/models/micropost_genre.rb
+++ b/app/models/micropost_genre.rb
@@ -1,0 +1,6 @@
+class MicropostGenre < ApplicationRecord
+  belongs_to :micropsot
+  belongs_to :genre
+
+  validates :micropost_id, uniqueness: { scope: :genre_id }
+end

--- a/app/serializers/genre_serializer.rb
+++ b/app/serializers/genre_serializer.rb
@@ -1,0 +1,3 @@
+class GenreSerializer < ActiveModel::Serializer
+  attributes :id, :name
+end

--- a/app/serializers/micropost_serializer.rb
+++ b/app/serializers/micropost_serializer.rb
@@ -1,6 +1,7 @@
 class MicropostSerializer < ActiveModel::Serializer
   attributes :id, :content, :title, :time, :created_at, :updated_at, :image_url
   belongs_to :user
+  has_many :genres
 
   def image_url
     if object.image.attached?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
       resources :likes, only: [:index, :create, :destroy]
     end
     resources :tags, only: %i[index]
+    resources :genres, only: %i[index]
     namespace :me do
       resource :account, only: %i[update]
     end

--- a/db/migrate/20210108112544_create_genres.rb
+++ b/db/migrate/20210108112544_create_genres.rb
@@ -1,0 +1,10 @@
+class CreateGenres < ActiveRecord::Migration[6.0]
+  def change
+    create_table :genres do |t|
+      t.string :name, null: false
+
+      t.timestamps
+      t.index :name, unique: true
+    end
+  end
+end

--- a/db/migrate/20210108112620_create_micropost_genres.rb
+++ b/db/migrate/20210108112620_create_micropost_genres.rb
@@ -1,0 +1,11 @@
+class CreateMicropostGenres < ActiveRecord::Migration[6.0]
+  def change
+    create_table :micropost_genres do |t|
+      t.references :micropost, null: false, foreign_key: true
+      t.references :genre, null: false, foreign_key: true
+
+      t.timestamps
+      t.index [:micropost_id, :genre_id], unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_07_150928) do
+ActiveRecord::Schema.define(version: 2021_01_08_112620) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -43,6 +43,13 @@ ActiveRecord::Schema.define(version: 2021_01_07_150928) do
     t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
+  create_table "genres", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["name"], name: "index_genres_on_name", unique: true
+  end
+
   create_table "likes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "micropost_id", null: false
@@ -50,6 +57,16 @@ ActiveRecord::Schema.define(version: 2021_01_07_150928) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["micropost_id"], name: "index_likes_on_micropost_id"
     t.index ["user_id"], name: "index_likes_on_user_id"
+  end
+
+  create_table "micropost_genres", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "micropost_id", null: false
+    t.bigint "genre_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["genre_id"], name: "index_micropost_genres_on_genre_id"
+    t.index ["micropost_id", "genre_id"], name: "index_micropost_genres_on_micropost_id_and_genre_id", unique: true
+    t.index ["micropost_id"], name: "index_micropost_genres_on_micropost_id"
   end
 
   create_table "microposts", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -102,6 +119,8 @@ ActiveRecord::Schema.define(version: 2021_01_07_150928) do
   add_foreign_key "comments", "users"
   add_foreign_key "likes", "microposts"
   add_foreign_key "likes", "users"
+  add_foreign_key "micropost_genres", "genres"
+  add_foreign_key "micropost_genres", "microposts"
   add_foreign_key "microposts", "users"
   add_foreign_key "user_tags", "tags"
   add_foreign_key "user_tags", "users"

--- a/test/controllers/api/genres_controller_test.rb
+++ b/test/controllers/api/genres_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class Api::GenresControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/genres.yml
+++ b/test/fixtures/genres.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/micropost_genres.yml
+++ b/test/fixtures/micropost_genres.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/genre_test.rb
+++ b/test/models/genre_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class GenreTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/micropost_genre_test.rb
+++ b/test/models/micropost_genre_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class MicropostGenreTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# why 
micopostにもジャンルタグを設定できるようにし、監視するため

# what
## バックエンド
- genre, micropost_genreモデルとコントローラーの作成

## フロントエンド
- modalで投稿を変種できるように変更
- 投稿編集画面でジャンルタグを設置できる
- 新規投稿時は未設定